### PR TITLE
Shorten queries in survey lists and results page

### DIFF
--- a/project/public_surveys.php
+++ b/project/public_surveys.php
@@ -17,11 +17,8 @@ if(isset($_POST["category_filter"])) {
 }
 if(isset($_POST["search"])) {
     $db = getDB();
-    $stmt = $db->prepare("SELECT qry.id, qry.title, qry.description, qry.category, qry.username, COUNT(r.survey_id) AS total 
-                          FROM (SELECT title, description, category, username, Surveys.id FROM Surveys JOIN Users ON Surveys.user_id = Users.id 
-                          WHERE title LIKE :tf AND category LIKE :cf AND visibility = 2 ORDER BY Surveys.created DESC LIMIT 10) AS qry 
-                          LEFT JOIN (SELECT DISTINCT user_id, survey_id FROM Responses) AS r ON qry.id = r.survey_id 
-                          GROUP BY qry.id, qry.title, qry.description, qry.category, qry.username");
+    $stmt = $db->prepare("SELECT DISTINCT s.*, u.username, (SELECT COUNT(DISTINCT user_id) FROM Responses r WHERE r.survey_id = s.id) AS total FROM Surveys s JOIN Users u ON s.user_id = u.id 
+                          LEFT JOIN Responses r ON s.id = r.survey_id WHERE title LIKE :tf AND category LIKE :cf AND visibility = 2 ORDER BY created DESC");
     $r = $stmt->execute([":tf" => "%$title_filter%", ":cf" => "%$category_filter%"]);
     if ($r) {
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -32,10 +29,8 @@ if(isset($_POST["search"])) {
 }
 else {
     $db = getDB();
-    $stmt = $db->prepare("SELECT qry.id, qry.title, qry.description, qry.category, qry.username, COUNT(r.survey_id) AS total 
-                          FROM (SELECT title, description, category, username, Surveys.id FROM Surveys JOIN Users ON Surveys.user_id = Users.id WHERE visibility = 2 
-                          ORDER BY Surveys.created DESC LIMIT 10) AS qry LEFT JOIN (SELECT DISTINCT user_id, survey_id FROM Responses) AS r ON qry.id = r.survey_id 
-                          GROUP BY qry.id, qry.title, qry.description, qry.category, qry.username");
+    $stmt = $db->prepare("SELECT DISTINCT s.*, u.username, (SELECT COUNT(DISTINCT user_id) FROM Responses r WHERE r.survey_id = s.id) AS total FROM Surveys s JOIN Users u ON s.user_id = u.id 
+                          LEFT JOIN Responses r ON s.id = r.survey_id WHERE visibility = 2 ORDER BY created DESC");
     $r = $stmt->execute();
     if ($r) {
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/project/taken_surveys.php
+++ b/project/taken_surveys.php
@@ -9,10 +9,8 @@ if(!is_logged_in()) {
 $results = [];
 $user_id = get_user_id();
 $db = getDB();
-$stmt = $db->prepare("SELECT qry.id, qry.title, qry.description, qry.category, qry.visibility, COUNT(r.survey_id) AS total 
-                      FROM (SELECT DISTINCT s.id, s.title, s.description, s.category, s.visibility, r.created FROM Surveys s JOIN Responses r ON s.id = r.survey_id 
-                      WHERE r.user_id = :uid ORDER BY r.created DESC LIMIT 10) AS qry LEFT JOIN (SELECT DISTINCT user_id, survey_id FROM Responses) AS r ON qry.id = r.survey_id 
-                      GROUP BY qry.id, qry.title, qry.description, qry.category, qry.visibility");
+$stmt = $db->prepare("SELECT DISTINCT s.*, r.created AS r_created, (SELECT COUNT(DISTINCT user_id) FROM Responses WHERE Responses.survey_id = s.id) AS total 
+                      FROM Surveys s JOIN Responses r ON s.id = r.survey_id WHERE r.user_id = :uid ORDER BY r_created DESC");
 $r = $stmt->execute([":uid" => $user_id]);
 if ($r) {
     $results = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/project/your_surveys.php
+++ b/project/your_surveys.php
@@ -9,9 +9,8 @@ if(!is_logged_in()) {
 $results = [];
 $user_id = get_user_id();
 $db = getDB();
-$stmt = $db->prepare("SELECT qry.id, qry.title, qry.description, qry.category, qry.visibility, COUNT(r.survey_id) AS total 
-                      FROM (SELECT * FROM Surveys WHERE user_id = :uid ORDER BY created DESC LIMIT 10) AS qry LEFT JOIN (SELECT DISTINCT user_id, survey_id FROM Responses) AS r 
-                      ON qry.id = r.survey_id GROUP BY qry.id, qry.title, qry.description, qry.category, qry.visibility");
+$stmt = $db->prepare("SELECT DISTINCT s.*, (SELECT COUNT(DISTINCT user_id) FROM Responses r WHERE r.survey_id = s.id) AS total FROM Surveys s JOIN Users u ON s.user_id = u.id 
+                      LEFT JOIN Responses r ON s.id = r.survey_id WHERE s.user_id = :uid ORDER BY created DESC");
 $r = $stmt->execute([":uid" => $user_id]);
 if ($r) {
     $results = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
While the queries written for the survey lists and results page work, they are also unnecessarily long. This PR will handle shortening of the aforementioned queries.